### PR TITLE
Fix pre-made do blocks expecting numerical action names

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1760,6 +1760,7 @@ function Blocks(canvas, stage, refreshCanvas, trashcan) {
         this.protoBlockDict['myDo_' + name] = myDoBlock;
         myDoBlock.oneArgBlock();
         myDoBlock.palette = this.palettes.dict['blocks'];
+        myDoBlock.docks[1][2] = 'anyin';
         myDoBlock.defaults.push(name);
         myDoBlock.staticLabels.push(_('do'));
         if (name == 'action') {


### PR DESCRIPTION
Steps to reproduce bug (prior to patch):

1. Make a new action
2. Give it a name other than action
3. Open the actions/boxes palette, there will be a pre-made do block
4. Drag out that do block
5. Notice the action name in purple (number)
6. Notice the crash trying to run "NaN"