### PR TITLE
Set Z values, don't swap children

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -739,7 +739,7 @@ define(function(require) {
                 if (!thumbnails.show(scale)) {
                     console.log('thumbnails not available');
                 } else if (!thumbnails.locked) {
-                    stage.swapChildren(thumbnails.container, last(stage.children));
+                    stage.setChildIndex(thumbnails.container, stage.getNumChildren() - 1);
                     thumbnailsVisible = true;
                     hideBlocks();
                 } else {
@@ -864,7 +864,7 @@ define(function(require) {
             var errorMsgContainer = errorMsgText.parent;
             errorMsgContainer.visible = true;
             errorMsgText.text = msg;
-            stage.swapChildren(errorMsgContainer, last(stage.children));
+            stage.setChildIndex(errorMsgContainer, stage.getNumChildren() - 1);
 
             if (blk !== undefined && blk !== null
                 && !blocks.blockList[blk].collapsed) {
@@ -881,7 +881,7 @@ define(function(require) {
                 var line = new createjs.Shape();
                 errorMsgArrow.addChild(line);
                 line.graphics.setStrokeStyle(4).beginStroke('#ff0031').moveTo(fromX, fromY).lineTo(toX, toY);
-                stage.swapChildren(errorMsgArrow, last(stage.children));
+                stage.setChildIndex(errorMsgArrow, stage.getNumChildren() - 1);
                 update = true;
 
                 var angle = Math.atan2(toX - fromX, fromY - toY) / Math.PI * 180;
@@ -893,7 +893,7 @@ define(function(require) {
                 head.rotation = angle;
             }
 
-            stage.swapChildren(errorMsgContainer, last(stage.children));
+            stage.setChildIndex(errorMsgContainer, stage.getNumChildren() - 1);
             errorMsgContainer.updateCache();
         }
 
@@ -1558,7 +1558,7 @@ define(function(require) {
                                 msgText.text = blocks.blockList[blk].value.toString();
                             }
                             msgContainer.updateCache();
-                            stage.swapChildren(msgContainer, last(stage.children));
+                            stage.setChildIndex(msgContainer, stage.getNumChildren() - 1);
                             stopTurtle = true;
                         } else {
                             errorMsg('I do not know how to ' + blocks.blockList[blk].name + '.', blk);
@@ -1651,9 +1651,9 @@ define(function(require) {
                 }
 
                 // Make sure the turtles are on top.
-                var lastChild = last(stage.children);
+                var i = stage.getNumChildren() - 1;
                 // for (var turtle = 0; turtle < turtles.turtleList.length; turtle++) {
-                stage.swapChildren(turtles.turtleList[turtle].Container, lastChild);
+                stage.setChildIndex(turtles.turtleList[turtle].Container, i);
                 // }
                 update = true;
             }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1191,8 +1191,8 @@ function Blocks(canvas, stage, refreshCanvas, trashcan) {
         myBlock.text.text = label;
 
         // Make sure text is on top.
-        lastChild = last(myBlock.container.children);
-        myBlock.container.swapChildren(myBlock.text, lastChild);
+        z = myBlock.container.getNumChildren() - 1;
+        myBlock.container.setChildIndex(myBlock.text, z);
 
         if (myBlock.loadComplete) {
             myBlock.container.updateCache();
@@ -2544,8 +2544,8 @@ function Block(protoblock, blocks) {
 
             if (me.text != null) {
                 // Make sure text is on top.
-                lastChild = last(me.container.children);
-                me.container.swapChildren(me.text, lastChild);
+                z = me.container.getNumChildren() - 1;
+                me.container.setChildIndex(me.text, z);
             }
 
             // At me point, it should be safe to calculate the
@@ -2638,8 +2638,8 @@ function Block(protoblock, blocks) {
             this.text.y = VALUETEXTY;
 
             // Make sure text is on top.
-            lastChild = last(this.container.children);
-            this.container.swapChildren(this.text, lastChild);
+            z = this.container.getNumChildren() - 1;
+            this.container.setChildIndex(this.text, z);
             this.container.updateCache();
         }
 
@@ -2655,8 +2655,8 @@ function Block(protoblock, blocks) {
             }
             this.text.y = VALUETEXTY;
 
-            lastChild = last(this.container.children);
-            this.container.swapChildren(this.text, lastChild);
+            z = this.container.getNumChildren() - 1;
+            this.container.setChildIndex(this.text, z);
             this.container.updateCache();
         }
 
@@ -2881,8 +2881,8 @@ function labelChanged(myBlock) {
     myBlock.label.style.display = 'none';
 
     // Make sure text is on top.
-    lastChild = last(myBlock.container.children);
-    myBlock.container.swapChildren(myBlock.text, lastChild);
+    var z = myBlock.container.getNumChildren() - 1;
+    myBlock.container.setChildIndex(myBlock.text, z);
     try {
         myBlock.container.updateCache();
     } catch (e) {
@@ -3135,8 +3135,8 @@ function collapseToggle(blocks, myBlock) {
                 myBlock.collapseText.text = '';
             }
         }
-        var lastChild = last(myBlock.container.children);
-        myBlock.container.swapChildren(myBlock.collapseText, lastChild);
+        var z = myBlock.container.getNumChildren() - 1;
+        myBlock.container.setChildIndex(myBlock.collapseText, z);
 
         if (blocks.dragGroup.length > 0) {
             for (var b = 0; b < blocks.dragGroup.length; b++) {
@@ -3282,9 +3282,9 @@ function loadEventHandlers(blocks, myBlock) {
         trashcan.show();
 
         // Bump the bitmap in front of its siblings.
-        blocks.stage.swapChildren(myBlock.container, last(blocks.stage.children));
+        blocks.stage.setChildIndex(myBlock.container, blocks.stage.getNumChildren() - 1);
         if (myBlock.collapseContainer != null) {
-            blocks.stage.swapChildren(myBlock.collapseContainer, last(blocks.stage.children));
+            blocks.stage.setChildIndex(myBlock.collapseContainer, blocks.stage.getNumChildren() - 1);
         }
 
         moved = false;
@@ -3340,8 +3340,8 @@ function loadEventHandlers(blocks, myBlock) {
 
             if (myBlock.isValueBlock() && myBlock.name != 'media') {
                 // Ensure text is on top
-                var lastChild = last(myBlock.container.children);
-                myBlock.container.swapChildren(myBlock.text, lastChild);
+                var z = myBlock.container.getNumChildren() - 1;
+                myBlock.container.setChildIndex(myBlock.text, z);
             } else if (myBlock.collapseContainer != null) {
                 myBlock.collapseContainer.x = myBlock.container.x + COLLAPSEBUTTONXOFF;
                 myBlock.collapseContainer.y = myBlock.container.y + COLLAPSEBUTTONYOFF;
@@ -3387,7 +3387,7 @@ function displayMsg(blocks, text) {
     msgContainer.visible = true;
     blocks.msgText.text = text;
     msgContainer.updateCache();
-    blocks.stage.swapChildren(msgContainer, last(blocks.stage.children));
+    blocks.stage.setChildIndex(msgContainer, blocks.stage.getNumChildren() - 1);
 }
 
 


### PR DESCRIPTION
Swapping children can have unintended effects, since the previous
top of stack shape can end up anywhere in the z stack!

Steps to reproduce 1 exmaple (before patch):

1. Add a forward block to the start
2. Remove the distance argument block
3. Press run
4. See the error
5. Drag the block

You should see the arrow in a weird Z position.

GCI Task:  http://www.google-melange.com/gci/task/view/google/gci2014/6155168651411456