### PR TITLE
Dock blocks on initial drag from palette

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -250,8 +250,8 @@ define(function(require) {
 
             trashcan = new Trashcan(canvas, stage, cellSize, refreshCanvas);
             turtles = new Turtles(canvas, stage, refreshCanvas);
-            palettes = initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan);
             blocks = new Blocks(canvas, stage, refreshCanvas, trashcan);
+            palettes = initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan, blocks);
 
             palettes.setBlocks(blocks);
             palettes.setDragging(setDraggingContainer);

--- a/js/palette.js
+++ b/js/palette.js
@@ -646,7 +646,8 @@ function Palette(palettes, name, color, bgcolor) {
 };
 
 
-function initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan) {
+var blocks = undefined;
+function initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan, b) {
     // Instantiate the palettes object on first load.
     var palettes = new Palettes(canvas, stage, cellSize, refreshCanvas, trashcan).
     add('turtle', 'black', '#00b700').
@@ -658,6 +659,7 @@ function initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan) {
     add('media', 'black', '#ffc000').
     add('sensors', 'white', '#ff0066').
     add('extras', 'white', '#ff0066');
+    blocks = b;
 
     // Give the palettes time to load.
     setTimeout(function() {
@@ -699,6 +701,9 @@ function loadPaletteMenuItemHandler(palette, blk, blkname) {
     }
 
     palette.protoContainers[blkname].on('mousedown', function(event) {
+        var stage = palette.palettes.stage;
+        stage.setChildIndex(palette.protoContainers[blkname], stage.getNumChildren() - 1);
+
         moved = false;
         saveX = palette.protoContainers[blkname].x;
         saveY = palette.protoContainers[blkname].y;
@@ -740,6 +745,8 @@ function loadPaletteMenuItemHandler(palette, blk, blkname) {
             for (i in paletteBlocks.dragGroup) {
                 paletteBlocks.moveBlockRelative(paletteBlocks.dragGroup[i], Math.round(event.stageX / palette.palettes.scale), Math.round(event.stageY / palette.palettes.scale));
             }
+            // Dock with other blocks if needed
+            blocks.blockMoved(newBlock);
         }
         // Return protoblock we've been dragging back to the palette.
         palette.protoContainers[blkname].x = saveX;


### PR DESCRIPTION
Steps to reproduce (before patch):

1. Try to drag a block into the "start" section
2. Move the start section
3. Notice the blocks did not connect
4. Drag the block again (to the start section)
5. Get annoyed about how it needs 2 drags