### PR TITLE
Drag to move blocks

### DIFF
--- a/js/artwork.js
+++ b/js/artwork.js
@@ -264,7 +264,7 @@ var PALETTEFILLER = '<svg xmlns="http://www.w3.org/2000/svg" width="200" height=
 
 var PALETTEHEADER = '<svg xmlns="http://www.w3.org/2000/svg" width="header_width" height="42">' + '<rect width="header_width" height="42" x="0" y="0" style="fill:fill_color;fill-opacity:1;stroke:none" />' + '<text style="font-size:16px;font-style:normal;font-weight:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill-opacity:1;stroke:none;font-family:Sans">' + '<tspan  x="55" y="30" style="font-size:24px;text-align:start;text-anchor:start;fill:#ffffff">palette_label</tspan>' + '</text>' + '</svg>';
 
-var PALETTEBUTTON = '<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55">' + '<rect width="55" height="55" x="0" y="0" style="fill:fill_color;fill-opacity:1;stroke:none" />' + '</svg>';
+var PALETTEBUTTON = '<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55">' + '<circle cx="27.5" cy="27.5" r="27.5" x="0" y="0" style="fill:fill_color;fill-opacity:1;stroke:none" />' + '</svg>';
 
 // samples-viewer related artwork
 

--- a/js/palette.js
+++ b/js/palette.js
@@ -64,7 +64,6 @@ function Palettes(canvas, stage, cellSize, refreshCanvas, trashcan) {
     // The collection of palettes.
     this.dict = {};
     this.buttons = {}; // The toolbar button for each palette.
-    this.bitmaps = {};
     this.highlightBitmaps = {};
 
     this.visible = true;
@@ -139,47 +138,36 @@ function Palettes(canvas, stage, cellSize, refreshCanvas, trashcan) {
                 this.buttons[name].x = this.x;
                 this.buttons[name].y = this.y + this.scrollDiff;
                 this.y += this.cellSize;
+                var me = this;
 
-                function processButton(me, name, bitmap, extras) {
-                    me.bitmaps[name] = bitmap;
-                    me.buttons[name].addChild(me.bitmaps[name]);
-                    if (me.cellSize != me.originalSize) {
-                        bitmap.scaleX = me.cellSize / me.originalSize;
-                        bitmap.scaleY = me.cellSize / me.originalSize;
-                    }
+                function processHighlightButton(me, name, bitmap, extras) {
+                    me.highlightBitmaps[name] = bitmap;
+                    me.buttons[name].addChild(me.highlightBitmaps[name]);
+                    me.highlightBitmaps[name].visible = false;
 
-                    function processHighlightButton(me, name, bitmap, extras) {
-                        me.highlightBitmaps[name] = bitmap;
-                        me.buttons[name].addChild(me.highlightBitmaps[name]);
-                        me.highlightBitmaps[name].visible = false;
-
-                        function processButtonIcon(me, name, bitmap, extras) {
-                            me.buttons[name].addChild(bitmap);
-                            if (me.cellSize != me.originalSize) {
-                                bitmap.scaleX = me.cellSize / me.originalSize;
-                                bitmap.scaleY = me.cellSize / me.originalSize;
-                            }
-
-                            var hitArea = new createjs.Shape();
-                            hitArea.graphics.beginFill('#FFF').drawEllipse(-me.halfCellSize, -me.halfCellSize, me.cellSize, me.cellSize);
-                            hitArea.x = me.halfCellSize;
-                            hitArea.y = me.halfCellSize;
-                            me.buttons[name].hitArea = hitArea;
-                            me.buttons[name].visible = false;
-
-                            me.dict[name].makeMenu();
-                            me.dict[name].moveMenu(me.cellSize, me.cellSize);
-                            me.dict[name].updateMenu(false);
-
-                            loadPaletteButtonHandler(me, name);
+                    function processButtonIcon(me, name, bitmap, extras) {
+                        me.buttons[name].addChild(bitmap);
+                        if (me.cellSize != me.originalSize) {
+                            bitmap.scaleX = me.cellSize / me.originalSize;
+                            bitmap.scaleY = me.cellSize / me.originalSize;
                         }
-                        makePaletteBitmap(me, PALETTEICONS[name], name, processButtonIcon, null);
+
+                        var hitArea = new createjs.Shape();
+                        hitArea.graphics.beginFill('#FFF').drawEllipse(-me.halfCellSize, -me.halfCellSize, me.cellSize, me.cellSize);
+                        hitArea.x = me.halfCellSize;
+                        hitArea.y = me.halfCellSize;
+                        me.buttons[name].hitArea = hitArea;
+                        me.buttons[name].visible = false;
+
+                        me.dict[name].makeMenu();
+                        me.dict[name].moveMenu(me.cellSize, me.cellSize);
+                        me.dict[name].updateMenu(false);
+
+                        loadPaletteButtonHandler(me, name);
                     }
-
-                    makePaletteBitmap(me, PALETTEBUTTON.replace('fill_color', '#4d4d4d'), name, processHighlightButton, null);
+                    makePaletteBitmap(me, PALETTEICONS[name], name, processButtonIcon, null);
                 }
-
-                makePaletteBitmap(this, PALETTEBUTTON.replace('fill_color', '#96d3f3'), name, processButton, null);
+                makePaletteBitmap(me, PALETTEBUTTON.replace('fill_color', '#4d4d4d'), name, processHighlightButton, null);
 
             }
         }
@@ -311,21 +299,18 @@ function loadPaletteButtonHandler(palettes, name) {
     // A palette button opens or closes a palette.
     palettes.buttons[name].on('mouseover', function(event) {
         palettes.setDraggingFlag(true);
-        palettes.bitmaps[name].visible = false;
         palettes.highlightBitmaps[name].visible = true;
         palettes.refreshCanvas();
     });
 
     palettes.buttons[name].on('pressup', function(event) {
         palettes.setDraggingFlag(false);
-        palettes.bitmaps[name].visible = true;
         palettes.highlightBitmaps[name].visible = false;
         palettes.refreshCanvas();
     });
 
     palettes.buttons[name].on('mouseout', function(event) {
         palettes.setDraggingFlag(false);
-        palettes.bitmaps[name].visible = true;
         palettes.highlightBitmaps[name].visible = false;
         palettes.refreshCanvas();
     });

--- a/js/palette.js
+++ b/js/palette.js
@@ -1015,7 +1015,7 @@ function loadPaletteMenuItemHandler(palette, blk, blkname) {
                 // Move the drag group under the cursor.
                 paletteBlocks.findDragGroup(newBlock);
                 for (i in paletteBlocks.dragGroup) {
-                    paletteBlocks.moveBlockRelative(paletteBlocks.dragGroup[i], Math.round(event.stageX / palette.palettes.scale), Math.round(event.stageY / palette.palettes.scale));
+                    paletteBlocks.moveBlockRelative(paletteBlocks.dragGroup[i], Math.round(event.stageX / palette.palettes.scale) - paletteBlocks.stage.x, Math.round(event.stageY / palette.palettes.scale) - paletteBlocks.stage.y);
                 }
                 // Dock with other blocks if needed
                 blocks.blockMoved(newBlock);

--- a/js/trash.js
+++ b/js/trash.js
@@ -78,6 +78,7 @@ function Trashcan (canvas, stage, size, refreshCanvas) {
     }
 
     this.stage.addChild(this.container);
+    this.stage.setChildIndex(this.container, 0);
     this.resizeEvent(1);
     makeTrash(this);
 


### PR DESCRIPTION
First commit:

> **Allow users to drag blocks around the canvas**
>
> Users can now touch-drag on the background to move blocks.  This
> makes it possible to have block stacks larger than the canvas.

2nd commit:

> **Better palette buttons when blocks are below them**
>
> This commit removes the (odd feeling) square background below the
> palette buttons.  The square of blue looks very weird when there are
> block under it.
>
> It also makes the highlight a square, which again looks more natural
> when it is below something.