### PR TITLE
Actually make the palette - so we can show it instead generating errors

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -813,6 +813,7 @@ function initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan, b) {
     add('media', 'black', '#ffc000').
     add('sensors', 'white', '#ff0066').
     add('extras', 'white', '#ff0066');
+    palettes.makeMenu();
     blocks = b;
 
     // Give the palettes time to load.


### PR DESCRIPTION
Tested in Firefox 34 on Fedora 21.  This patch means I can actually use
TurtleBlocks js instead of just staring at the beautiful start block.