### PR TITLE
Refactor the input system

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -1,5 +1,7 @@
 body {
     background-color: #99CCFF;
+    padding: 0;
+    margin: 0;
 }
 
 #main-toolbar #activity-button {
@@ -49,24 +51,24 @@ input.savename {
    font-size: 150% !important;
 }
 
-textarea.text {
+input.text {
    background-color: #ffc000;
    text-align: center;
-   font-size: 150% !important;
    font-weight: bold !important;
    resize: none !important;
    padding: 0 !important;
    border: 0 !important;
+   width: 100px;
 }
 
-textarea.number {
-   background-color: #ff00ff;
+input.number {
+   background-color: #ff00ff !important;
    text-align: center;
-   font-size: 150% !important;
    font-weight: bold !important;
    resize: none !important;
    padding: 0 !important;
    border: 0 !important;
+   width: 100px;
 }
 
 #canvas {

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Turtle Blocks JS</title>
     <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height"/>
-    <link rel="stylesheet" media="not screen and (device-width: 1200px) and (device-height: 900px)" href="lib/sugar-web/graphics/css/sugar-96dpi.css">
+    <!-- <link rel="stylesheet" media="not screen and (device-width: 1200px) and (device-height: 900px)" href="lib/sugar-web/graphics/css/sugar-96dpi.css">
     <link rel="stylesheet" media="screen and (device-width: 1200px) and (device-height: 900px)" href="lib/sugar-web/graphics/css/sugar-200dpi.css">
-    <link rel="stylesheet" href="lib/sugar-web/graphics/css/sugar.css">
+    <link rel="stylesheet" href="lib/sugar-web/graphics/css/sugar.css"> -->
     <link rel="stylesheet" href="css/activity.css">
 
     <script src="lib/mespeak.js"></script>

--- a/js/activity.js
+++ b/js/activity.js
@@ -296,7 +296,7 @@ define(function(require) {
 
             trashcan = new Trashcan(canvas, stage, cellSize, refreshCanvas);
             turtles = new Turtles(canvas, stage, refreshCanvas);
-            blocks = new Blocks(canvas, blocksContainer, refreshCanvas, trashcan);
+            blocks = new Blocks(canvas, blocksContainer, refreshCanvas, trashcan, stage.update);
             palettes = initPalettes(canvas, stage, cellSize, refreshCanvas, trashcan, blocks);
 
             palettes.setBlocks(blocks);
@@ -497,6 +497,7 @@ define(function(require) {
                     blocksContainer.x += event.stageX - lastCords.x;
                     blocksContainer.y += event.stageY - lastCords.y;
                     lastCords = {x: event.stageX, y: event.stageY};
+                    stage.update();
                 });
 
                 stage.on('stagemouseup', function (event) {
@@ -598,6 +599,10 @@ define(function(require) {
         };
 
         function keyPressed(event) {
+            if (docById('labelDiv').classList.contains('hasKeyboard')) {
+                return;
+            }
+
             var ESC = 27;
             var ALT = 18;
             var CTRL = 17;
@@ -653,6 +658,10 @@ define(function(require) {
         }
 
         function onResize() {
+            if (docById('labelDiv').classList.contains('hasKeyboard')) {
+                return;
+            }
+
             if (!onAndroid) {
                 var w = window.innerWidth;
                 var h = window.innerHeight;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -23,13 +23,14 @@ var VIDEOVALUE = '##__VIDEO__##';
 // Blocks holds the list of blocks and most of the block-associated
 // methods, since most block manipulations are inter-block.
 
-function Blocks(canvas, stage, refreshCanvas, trashcan) {
+function Blocks(canvas, stage, refreshCanvas, trashcan, updateStage) {
     // Things we need from outside include access to the canvas, the
     // stage, and the trashcan.
     this.canvas = canvas;
     this.stage = stage;
     this.refreshCanvas = refreshCanvas;
     this.trashcan = trashcan;
+    this.updateStage = updateStage;
 
     // We keep a dictionary for the proto blocks,
     this.protoBlockDict = {}


### PR DESCRIPTION
* Easier to trigger inputs on touch
* Scale font size and width to canvas scale
* Use input[type=number] so you have a num pad
* Move block to the top of the screen if the person uses touch (so it is
  still visible when the viewpoint changes to show the keyboard)
* Don't re-scale when the viewpoint changes during typing because:
	* It could just be mobile keyboard popup
	* Don't move the block from under the input!
* Delete the input if somebody de-focuses (blurs) it

Sorry, I should have made these into more than 1 of commit :)