### PR TITLE
Ignoring MusicBlocks_ files from the server when loading up the templates

### DIFF
--- a/js/samplesviewer.js
+++ b/js/samplesviewer.js
@@ -78,7 +78,8 @@ function PlanetModel(controller) {
             var todo = [];
             l.forEach(function (name, i) {
                 if (name.indexOf('.b64') !== -1) 	{
-                    todo.push(name);
+                    if(!(name.slice(0, 'MusicBlocks_'.length) == 'MusicBlocks_'))
+                        todo.push(name);
                 }
             });
             me.getImages(todo);


### PR DESCRIPTION
Report: https://markable.in/file/5b2c9fa0-bf7d-11e5-a6fb-0a41a440e2ed.html

GCI Task: https://codein.withgoogle.com/dashboard/task-instances/5958307437084672/?sp-page=1