### PR TITLE
Fixed bug #258 - Before and after resizing turtle position changes

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1181,6 +1181,13 @@ define(function (require) {
                 palettes.setMobile(false);
                 palettes.bringToTop();
             }
+            for (var turtle = 0; turtle < turtles.turtleList.length; turtle++) {
+                var tur = turtles.turtleList[turtle];
+                tur.clearPenStrokes();
+                tur.container.x = tur.turtles.turtleX2screenX(tur.x);
+                tur.container.y = tur.turtles.turtleY2screenY(tur.y);
+                tur.turtles.refreshCanvas();
+            }
         };
 
         window.onresize = function () {

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -568,6 +568,27 @@ function Turtle (name, turtles, drum) {
         this.turtles.refreshCanvas();
     };
 
+    this.clearPenStrokes = function() {
+        this.penState = true;
+        this.fillState = false;
+        this.hollowState = false;
+
+        this.canvasColor = getMunsellColor(this.color, this.value, this.chroma);
+        if (this.canvasColor[0] === "#") {
+            this.canvasColor = hex2rgb(this.canvasColor.split("#")[1]);
+        }
+
+        this.drawingCanvas.graphics.clear();
+        var subrgb = this.canvasColor.substr(0, this.canvasColor.length-2);
+        this.drawingCanvas.graphics.beginStroke(subrgb + this.canvasAlpha + ")");
+        this.drawingCanvas.graphics.setStrokeStyle(this.stroke, 'round', 'round');
+
+        this.svgOutput = '';
+        this.svgPath = false;
+
+        this.turtles.refreshCanvas();
+    };
+
     this.doForward = function(steps) {
         if (!this.fillState) {
             if (this.canvasColor[0] === "#") {


### PR DESCRIPTION
This is for Google Code-In 2016: eohomegrownapps

After resizing, the turtle now moves to the correct coordinates
on-screen. Any pen strokes the turtle has created will be cleared. As
the pen strokes are stored on the canvas as SVG, resizing them would
either require an overhaul of the entire pen-drawing code or complex
SVG parsing; personally I think neither are worth the effort for the
very small benefit gained as the lines can very easily be redrawn after
resizing the screen by running the turtle blocks. There is a precedent
for this sort of thing - for example the popular maths app GeoGebra
removes the traces points have left after the screen is resized.