### PR TITLE
Fixed #237 #275; eliminated Chrome related click detection issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,10 +92,10 @@
 
         <div id="labelDiv"></div>
         <div id="ioDiv">
-          <input class="file" type="file" id="myMedia" accept="image/*"/>
-          <input class="file" type="file" id="myOpenFile" accept=".ta, .tb"/>
-          <input class="file" type="file" id="myOpenPlugin" accept=".json"/>
-          <input class="file" type="file" id="myOpenAll" />
+          <input class="file" tabindex="-1" type="file" id="myMedia" accept="image/*"/>
+          <input class="file" tabindex="-1" type="file" id="myOpenFile" accept=".ta, .tb"/>
+          <input class="file" tabindex="-1" type="file" id="myOpenPlugin" accept=".json"/>
+          <input class="file" tabindex="-1" type="file" id="myOpenAll" />
   <!-- <input class="file" type="file" id="mySaveFile" accept=".ta, .tb" nwsaveas="turtle-project.tb" /> -->
         </div>
         <div id="audio"></div>

--- a/js/block.js
+++ b/js/block.js
@@ -1380,11 +1380,12 @@ function Block(protoblock, blocks, overrideName) {
                 // apart). Still need to get to the root cause.
                 this.blocks.adjustDocks(this.blocks.blockList.indexOf(this), true);
             }
-        } else if (['text', 'solfege', 'notename', 'number', 'media', 'loadFile'].indexOf(this.name) !== -1) {
+        }
+        if (['text', 'solfege', 'notename', 'number', 'media', 'loadFile'].indexOf(this.name) !== -1) {
             if (!haveClick) {
-                // Simulate click on Android.
+                // Simulate click on mobile devices.
                 var d = new Date();
-                if ((d.getTime() - blocks.mouseDownTime) < 500) {
+                if ((d.getTime() - blocks.mouseDownTime) < 200) {
                     if(!this.trash)
                     {
                         var d = new Date();


### PR DESCRIPTION
OUTDATED: " Chrome has seemed to that some clicks as dragging events. It has been eliminated with adequate workaround - events shorter than 150ms are now never considered dragging events - it doesn't affect usability and comfort. Outdated / unneeded pieces of code has been removed too. "

EDIT: Chrome has seemed to that some clicks as dragging events. It has been eliminated by fixing conditions of @walterbender 's workaround - events shorter than 200ms are now always considered clicks (regardless of movement) - it doesn't affect usability and comfort. `tabindex`es were added to avoid tabbing to the hidden input on mobile devices. 

PR fixes both #237 (we are now able to choose a file on Android) and #275 (error with unchangable text blocks seem to occur never more). 