### PR TITLE
Fixes Dragging issue

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1313,7 +1313,11 @@ function Block(protoblock, blocks, overrideName) {
 
                 var dx = Math.round(Math.round(event.stageX / scale) + offset.x - oldX);
                 var dy = Math.round(Math.round(event.stageY / scale) + offset.y - oldY);
+                var finalPos = oldY + dy;
 
+                if (blocks.stage.y === 0 && finalPos < (45*scale)){
+                	dy += (45*scale) - finalPos;
+                }
                 // Move this block...
                 blocks.moveBlockRelative(thisBlock, dx, dy);
 


### PR DESCRIPTION
This PR fixes the issue of not being able to drag blocks down from the top of the screen.
My solution to this problem involves setting a minimum y position for a block during drag which is ignored during scrolling since it will be invalid to set a minimum y position for a block during scrolling.
 I have chosen (45 * scale) which works perfectly for my computer but needs to be checked for other computer screen combinations. 
This issue is similar to @[https://github.com/walterbender/musicblocks/issues/396](url) 