### PR TITLE
Fixed #322; scrollbar visible never more during loading

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -216,7 +216,6 @@ input.number {
     border: 0 !important;
     background: rgba(255, 225, 255, 0.85);
     -webkit-user-select: none;
-    overflow-x: scroll !important;
 }
 
 /*# sourceMappingURL=activity.css.map */

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         <div id="tourData"></div>
     </div>
 
-    <div id="statusmatrix" overflow-x="auto" ondrag="moveStatusMatrix(event)" onmouseup="moveStatusMatrix(event)"></div>
+    <div id="statusmatrix" style="overflow-x: hidden" ondrag="moveStatusMatrix(event)" onmouseup="moveStatusMatrix(event)"></div>
     <div id="helpElem"></div>
     <div id="description"></div>
 

--- a/js/status.js
+++ b/js/status.js
@@ -41,7 +41,7 @@ function StatusMatrix() {
         // FIXME: make this number based on canvas size.
         var w = window.innerWidth;
         this._cellScale = w / 1200;
-        docById('statusmatrix').style.overflowX = 'auto';
+        docById('statusmatrix').style.overflowX = 'scroll';
 
         // Used to remove the matrix table
         Element.prototype.remove = function() {


### PR DESCRIPTION
`statusmatrix` had always had visible scrollbar, even while loading. I've changed it to display only when `statusmatrix` is initialized. 