### PR TITLE
Repeat block issue

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -22,6 +22,7 @@ const NOINPUTERRORMSG = 'Missing argument.';
 const NOSQRTERRORMSG = 'Cannot take square root of negative number.';
 const ZERODIVIDEERRORMSG = 'Cannot divide by zero.';
 const EMPTYHEAPERRORMSG = 'empty heap.';
+const POSNUMBER = 'Argument must be a positive number';
 
 const NOTE = ['A', 'A♯/B♭', 'B', 'C', 'C♯/D♭', 'D', 'D♯/E♭', 'E', 'F', 'F♯/G♭', 'G', 'G♯/A♭'];
 
@@ -748,6 +749,8 @@ function Logo(canvas, blocks, turtles, stage, refreshCanvas, textMsg, errorMsg,
                 if (typeof(args[0]) === 'string') {
                     logo.errorMsg(NANERRORMSG, blk);
                     logo.stopTurtle = true;
+                } else if (args[0] <= 0) {
+                    logo.errorMsg(POSNUMBER, blk);
                 } else {
                     childFlow = args[1];
                     childFlowCount = Math.floor(args[0]);


### PR DESCRIPTION
This PR fixes issue #516 in MB which is necessary in TB as well ; repeat block shows undefined behaviour when it is given a negative number.
Now,TB throws an error when the argument to repeat block is a negative number and skips the repeat block. The error thrown is "Argument must be a positive number".
@walterbender , please review :)