### PR TITLE
Fix broken images on GitHub README.md pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,40 +46,40 @@ A guide to programming with Turtle Blocks is available in [Turtle Blocks Guide](
 
 A quick start:
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fast-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fast-button.png' />
 Run your project at full speed
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop-turtle-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop-turtle-button.png' />
 Stop the current project running.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear-button.png' />
 Clear the screen and return the turtles to their initial positions.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/palette-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/palette-button.png' />
 Hide or show the block palettes.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide-blocks-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide-blocks-button.png' />
 Hide or show the blocks and the palettes.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forward.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forward.svg' />
 Moves turtle forward.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/right.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/right.svg' />
 Turns turtle clockwise (angle in degrees).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_color.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_color.svg' />
 Sets color of the line drawn by the turtle.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_pen_size.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_pen_size.svg' />
 Sets size of the line drawn by the turtle.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/repeat.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/repeat.svg' />
 Loops specified number of times.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action_flow.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action_flow.svg' />
 Top of nameable action stack.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action.svg' />
 Invokes named action stack.
 
 Google Code-in participant Jasmine Park has created some guides to

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -38,45 +38,45 @@ Main toolbar
 The Main toolbar is used to run programs, erase the screen, and hide
 the palettes and blocks.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fast-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fast-button.png' />
 
 Run the blocks fast.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/slow-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/slow-button.png' />
 
 Run the blocks slowly. When running slowly, the values of parameter
 boxes are shown as an additional debugging aid.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/step-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/step-button.png' />
 
 Run the blocks step by step (one block is executed per turtle per click).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop-turtle-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop-turtle-button.png' />
 
 Stop running the current project.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear-button.png' />
 
 Clear the screen and return the turtles to their initial positions in
 the center of the screen.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/palette-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/palette-button.png' />
 
 Hide or show the block palettes.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide-blocks-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide-blocks-button.png' />
 
 Hide or show the blocks and the block palettes.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/collapse-blocks-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/collapse-blocks-button.png' />
 
 Expand or collapse stacks of blocks (start and action stacks).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/help-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/help-button.png' />
 
 Show the help messages.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/menu-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/menu-button.png' />
 
 Expand or collapse the auxillary toolbar.
 
@@ -89,11 +89,11 @@ programs, overlaying grids, and accessing the utility panel. The
 Auxillary toolbar button on the Main toolbar (top right) is used to
 show/hide the Auxillary toolbar.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/planet-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/planet-button.png' />
 
 Open a viewer for loading example projects.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/copy-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/copy-button.png' />
 
 Copy blocks onto the clipboard. (This button appears at the top of a
 stack after a "long press".)
@@ -102,30 +102,30 @@ Also shown on after a long press is the Save Action-stack button. This
 will save an action stack on the custom palette for use in other
 projects.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/paste-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/paste-button.png' />
 
 Paste blocks from the clipboard. (This button is highlighted only when
 there are blocks available on the clipboard to paste.)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/Cartesian-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/Cartesian-button.png' />
 
 Show or hide a Cartesian-coordinate grid.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/polar-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/polar-button.png' />
 
 Show or hide a polar-coordinate grid.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/utility-button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/utility-button.svg' />
 
 Open utility panel to access controls for changing block size, loading
 plugins, looking at project statistics, and enabling/disabling
 scrolling.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/empty-trash-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/empty-trash-button.png' />
 
 Remove all blocks.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/restore-trash-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/restore-trash-button.png' />
 
 Restore blocks from the trash.
 
@@ -134,23 +134,23 @@ Utility panel
 
 The utility panel has some useful but seldom used controls.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/smaller-button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/smaller-button.svg' />
 
 Decrease the size of the blocks.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/bigger-button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/bigger-button.svg' />
 
 Increase the size of the blocks.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stats-button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stats-button.svg' />
 
 Show project statistics.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/plugin-button.png'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/plugin-button.png' />
 
 Load new blocks from plugins (previously downloaded to the file system).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/scrolllock-button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/scrolllock-button.svg' />
 
 Enable/disable scrolling.
 
@@ -167,456 +167,456 @@ more details on how to use the blocks.
 Turtle Palette
 --------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/clear.svg' />
 
 Clear the screen and reset the turtle.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forward.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forward.svg' />
 
 Move turtle forward.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/right.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/right.svg' />
 
 Turn turtle clockwise (angle in degrees).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/back.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/back.svg' />
 
 Move turtle backward.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/left.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/left.svg' />
 
 Turn turtle counterclockwise (angle in degrees).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arc.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arc.svg' />
 
 Move turtle along an arc.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_heading.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_heading.svg' />
 
 Set the heading of the turtle (0 is towards the top of the screen).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heading.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heading.svg' />
 
 The current heading of the turtle (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/setxy.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/setxy.svg' />
 
 Move turtle to position xcor, ycor; (0, 0) is in the center of the screen.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/x.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/x.svg' />
 
 Current x-coordinate value of the turtle (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/y.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/y.svg' />
 
 Current y-coordinate value of the turtle (can be used in place of a number block)
 
 Pen Palette
 -----------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_color.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_color.svg' />
 
 Set color of the line drawn by the turtle (hue, shade, and grey).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/color.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/color.svg' />
 
 Current pen color (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_hue.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_hue.svg' />
 
 Set hue of the line drawn by the turtle (hue is the spectral color, e.g., red, orange, yellow, green, blue, purple, etc.).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_shade.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_shade.svg' />
 
 Set shade of the line drawn by the turtle (shade is lightness, e.g., black, grey, white).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/shade.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/shade.svg' />
 
 Current pen shade (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_grey.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_grey.svg' />
 
 Set grey level of the line drawn by the turtle (grey is vividness or saturation).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/grey.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/grey.svg' />
 
 Current grey level (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_pen_size.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_pen_size.svg' />
 
 Set size of the line drawn by the turtle.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_size.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_size.svg' />
 
 Current pen size (can be used in place of a number block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_up.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_up.svg' />
 
 Turtle will not draw when moved.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_down.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pen_down.svg' />
 
 Turtle will draw when moved.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fill.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/fill.svg' />
 
 Draw filled polygon.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hollow.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hollow.svg' />
 
 Set pen attribute to hollow line mode (useful for working with 3D printers).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_font.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_font.svg' />
 
 Set the font of the text drawn with Show Block.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/background.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/background.svg' />
 
 Set the background color.
 
 Number Palette
 --------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/number.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/number.svg' />
 
 Use as numeric input in mathematic operators (click to change the value).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/random.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/random.svg' />
 
 Returns random number between minimum (top) and maximum (bottom) values
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/one-of.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/one-of.svg' />
 
 Returns one of two inputs as determined by a coin toss (random selection)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/plus.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/plus.svg' />
 
 Adds two numeric inputs (also can be used to concatenate two strings)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/subtract.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/subtract.svg' />
 
 Subtracts bottom numeric input from top numeric input
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/multiply.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/multiply.svg' />
 
 Multiplies two numeric inputs
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/divide.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/divide.svg' />
 
 Divides top numeric input (numerator) by bottom numeric input (denominator)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/sqrt.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/sqrt.svg' />
 
 Calculates square root
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/int.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/int.svg' />
 
 Converts real numbers to integers
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mod.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mod.svg' />
 
 Returns top input modular (remainder) bottom input.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/eval.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/eval.svg' />
 
 A programmable block used to add advanced single-variable math equations, e.g., sin(x).
 
 Boolean Palette
 ---------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/greater_than.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/greater_than.svg' />
 
 Logical greater-than operator
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/less_than.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/less_than.svg' />
 
 Logical less-than operator
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/equal.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/equal.svg' />
 
 Logical equal-to operator
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/and.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/and.svg' />
 
 Logical AND operator
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/or.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/or.svg' />
 
 Logical OR operator
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/not.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/not.svg' />
 
 Logical NOT operator
 
 Flow Palette
 ------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/repeat.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/repeat.svg' />
 
 Loops specified number of times through enclosed blocks
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forever.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/forever.svg' />
 
 Loops forever through enclosed blocks
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop.svg' />
 
 Stops current loop or action
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/if.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/if.svg' />
 
 If-then operator that uses boolean operators to determine whether or not to run encloded "flow"
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/until.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/until.svg' />
 
 Do-until-True operator that uses boolean operators to determine how long to run enclosed "flow"
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/wait_for.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/wait_for.svg' />
 
 Waits for condition
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/while.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/while.svg' />
 
 Do-while-True operator that uses boolean operators to determine how long to run enclosed "flow"
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/if_else.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/if_else.svg' />
 
 If-then-else operator that uses boolean operators to determine which encloded "flow" to run
 
 Boxes Palette
 -------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/storein.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/storein.svg' />
 
 Stores value in named variable.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/box_value.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/box_value.svg' />
 
 Named variable
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/add_1_to.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/add_1_to.svg' />
 
 Adds 1 to named variable
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/add_to.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/add_to.svg' />
 
 Adds numeric value to named variable
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/box.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/box.svg' />
 
 Named variable (name is passed as input)
 
 Action Palette
 --------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action_flow.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action_flow.svg' />
 
 Top of nameable action stack
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/action.svg' />
 
 Invokes named action stack
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/do_arg.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/do_arg.svg' />
 
 Invokes an action stack with arguments (To add more arguments, drag them into the clamp.)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/calc.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/calc.svg' />
 
 Invokes an action stack that returns a value
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/calc_arg.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/calc_arg.svg' />
 
 Invokes an action stack with arguments that returns a value
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/return.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/return.svg' />
 
 Returns a value from an action stack
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arg.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arg.svg' />
 
 An argument passed to an action stack
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arg1.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/arg1.svg' />
 
 The first argument passed to an action stack
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/start.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/start.svg' />
 
 Connects action to toolbar run buttons (each Start Block invokes its own turtle)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/do.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/do.svg' />
 
 Invokes named action stack (name is passed as input)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/event_on_do.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/event_on_do.svg' />
 
 Connects an action with an event
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/broadcast.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/broadcast.svg' />
 
 Broadcasts an event (event name is given as input)
 
 Media Palette
 -------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/speak.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/speak.svg' />
 
 Speaks text
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show.svg' />
 
 Draws text or shows media (from the camera, the Web, or the file system).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/size_shell_image.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/size_shell_image.svg' />
 
 Puts a custom "shell" on the turtle (used to turn a turtle into a "sprite")
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/text.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/text.svg' />
 
 Text (string) value
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/load-media.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/load-media.svg' />
 
 Opens a file-open dialog to load an image (used with Show Block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/camera.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/camera.svg' />
 
 Accesses webcam (used with Show Block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/video.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/video.svg' />
 
 Opens a file-open dialog to load a video (used with Show Block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/open_file.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/open_file.svg' />
 
 Returns the selected file (used with Show Block)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop_media.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop_media.svg' />
 
 Stops the media being played
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/tone.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/tone.svg' />
 
 Plays a tone at frequency (Hz) and duration (in seconds)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/note_to_frequency.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/note_to_frequency.svg' />
 
 Converts notes to frequency, e.g., A4 --> 440 Hz.
 
 Sensor Palette
 --------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/time.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/time.svg' />
 
 Elapsed time (in seconds) since program started
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_x.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_x.svg' />
 
 Returns mouse X coordinate
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_y.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_y.svg' />
 
 Returns mouse Y coordinate
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_button.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/mouse_button.svg' />
 
 Returns True if mouse button is pressed
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/keyboard.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/keyboard.svg' />
 
 Holds results of query-keyboard block as ASCII
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pixel_color.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pixel_color.svg' />
 
 Returns pixel color under turtle
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/loudness.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/loudness.svg' />
 
 Microphone input volume
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/click.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/click.svg' />
 
 The "click" event associated with a turtle (used with Do Block)
 
 Heap Palette
 ------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/push.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/push.svg' />
 
 Push a value onto the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pop.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/pop.svg' />
 
 Pop a value off of the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/index_heap.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/index_heap.svg' />
 
 Reference an entry in the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_heap_entry.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/set_heap_entry.svg' />
 
 Change an entry in the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show_heap.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show_heap.svg' />
 
 Display the contents of the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heap_length.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heap_length.svg' />
 
 The length of the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/empty_heap.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/empty_heap.svg' />
 
 Empty the heap.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heap_empty.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/heap_empty.svg' />
 
 True is the heap is empty.
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/save_heap.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/save_heap.svg' />
 
 Save the heap to a file (JSON-encoded).
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/load_heap.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/load_heap.svg' />
 
 Load the heap from a file (JSON-encoded).
 
 Extras Palette
 --------------
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/vspace.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/vspace.svg' />
 
 Used to layout blocks vertically
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hspace.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hspace.svg' />
 
 Used to layout blocks horizontally
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/wait.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/wait.svg' />
 
 Pauses turtle a specified number of seconds
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/print.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/print.svg' />
 
 Prints value
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/save_svg.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/save_svg.svg' />
 
 Saves turtle graphics as an SVG file
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show_blocks.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/show_blocks.svg' />
 
 Shows blocks and runs slowly (used to isolate code during debugging)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide_blocks.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/hide_blocks.svg' />
 
 Hides blocks and runs at full speed (used to isolate code during debugging)
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/play_back.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/play_back.svg' />
 
 Plays media
 
-<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop_play.svg'</img>
+<img src='https://rawgithub.com/walterbender/turtleblocksjs/master/documentation/stop_play.svg' />
 
 Stops playing media


### PR DESCRIPTION
It turns out this issue was not only on the Spanish guide but on other README.MD files as well.

Note that this is only an issue on the markdown visualization in Github, if you load the index.html pages on each of the folders, they work fine. This branch on our fork displays the images correctly, confirming the fix.