### PR TITLE
#276: Fixed SVG output for Bezier Curves

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -163,9 +163,7 @@ function Turtle (name, turtles, drum) {
             var cx2Scaled = (cx2 + dxf) * this.turtles.scale;
             var cy2Scaled = (cy2 + dyf) * this.turtles.scale;
 
-            ctx.moveTo(ax, ay);
             this.svgPath = true;
-            this.svgOutput += '<path d="M ' + axScaled + ',' + ayScaled + ' ';
 
             // Initial arc
             var oAngleRadians = ((180 + degreesInitial) / 180) * Math.PI;
@@ -176,12 +174,6 @@ function Turtle (name, turtles, drum) {
             ctx.arc(arccx, arccy, step, sa, ea, false);
             this._svgArc(steps, arccx * this.turtles.scale, arccy * this.turtles.scale, step * this.turtles.scale, sa, ea);
 
-            // Initial bezier curve
-            ctx.bezierCurveTo(cx1 + dxi, cy1 + dyi , cx2 + dxf, cy2 + dyf, cx, cy);
-            this.svgOutput += 'C ' + cx1Scaled + ',' + cy1Scaled + ' ' + cx2Scaled + ',' + cy2Scaled + ' ' + cxScaled + ',' + cyScaled + ' ';
-
-            this.svgOutput += 'M ' + cxScaled + ',' + cyScaled + ' ';
-
             // Final arc
             var oAngleRadians = (degreesFinal / 180) * Math.PI;
             var arccx = fx;
@@ -191,10 +183,10 @@ function Turtle (name, turtles, drum) {
             ctx.arc(arccx, arccy, step, sa, ea, false);
             this._svgArc(steps, arccx * this.turtles.scale, arccy * this.turtles.scale, step * this.turtles.scale, sa, ea);
 
-            // Final bezier curve
-            ctx.bezierCurveTo(cx2 - dxf, cy2 - dyf, cx1 - dxi, cy1 - dyi, ax, ay);
-            this.svgOutput += 'C ' + cx2Scaled + ',' + cy2Scaled + ' ' + cx1Scaled + ',' + cy1Scaled + ' ' + axScaled + ',' + ayScaled + ' ';
-            this.closeSVG();
+            var fx = this.turtles.turtleX2screenX(x2);
+            var fy = this.turtles.turtleY2screenY(y2);
+            var fxScaled = fx * this.turtles.scale;
+            var fyScaled = fy * this.turtles.scale;
 
             ctx.stroke();
             ctx.closePath();
@@ -203,6 +195,7 @@ function Turtle (name, turtles, drum) {
             ctx.lineWidth = this.stroke;
             ctx.lineCap = 'round';
             ctx.moveTo(fx,fy);
+            this.svgOutput += 'M ' + fxScaled + ',' + fyScaled + ' ';
             this.x = x2;
             this.y = y2;
         } else if (this.penState) {
@@ -220,6 +213,8 @@ function Turtle (name, turtles, drum) {
             var cx2 = this.turtles.turtleX2screenX(cp2x);
             var cy2 = this.turtles.turtleY2screenY(cp2y);
 
+            ctx.bezierCurveTo(cx1 + dxi, cy1 + dyi , cx2 + dxf, cy2 + dyf, cx, cy);
+            ctx.bezierCurveTo(cx2 - dxf, cy2 - dyf, cx1 - dxi, cy1 - dyi, ax, ay);
             ctx.bezierCurveTo(cx1, cy1, cx2, cy2, fx, fy);
 
             if (!this.svgPath) {
@@ -237,7 +232,11 @@ function Turtle (name, turtles, drum) {
             var cy2Scaled = cy2 * this.turtles.scale;
             var fxScaled = fx * this.turtles.scale;
             var fyScaled = fy * this.turtles.scale;
+
+            //Curve to: ControlPointX1, ControlPointY1 >> ControlPointX2, ControlPointY2 >> X, Y
             this.svgOutput += 'C ' + cx1Scaled + ',' + cy1Scaled + ' ' + cx2Scaled + ',' + cy2Scaled + ' ' + fxScaled + ',' + fyScaled;
+            this.closeSVG();
+
             this.x = x2;
             this.y = y2;
             ctx.stroke();
@@ -411,7 +410,7 @@ function Turtle (name, turtles, drum) {
             this.startBlock.value = this.turtles.turtleList.indexOf(this);
         }
     };
-    
+
     this.arc = function(cx, cy, ox, oy, x, y, radius, start, end, anticlockwise, invert) {
         if (invert) {
             cx = this.turtles.turtleX2screenX(cx);


### PR DESCRIPTION
Hi :)

With regard to #276, I have actually found the fix for the SVG output for the Bezier curve, by cleaning up the initial and final svgoutput for Bezier curves. 

Previously, it looks like:
![Old](https://image.ibb.co/hZAFkR/Screen_Shot_2017_12_21_at_7_31_53_PM.png)

Now, it is rendered correctly: 
![New](https://image.ibb.co/bF40kR/Screen_Shot_2017_12_21_at_7_35_53_PM.png)
