### PR TITLE
Fixed Link

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,7 +4,7 @@ Plugins
 How to get plugins
 ------------------
 
-You can find plugins in the [official app repository](https://github.com/walterbender/turtleblocksjs/plugins).
+You can find plugins in the [official app repository](https://github.com/walterbender/turtleblocksjs/tree/master/plugins).
 The plugins are identified by the extension <code>**.json**</code>
 You need to download the plugins to load it.
 [(In this guide I will use this plugin)](https://github.com/walterbender/turtleblocksjs/blob/master/plugins/translate.json)


### PR DESCRIPTION
Earlier it was returning 404 error.

Also there is an image with this link: https://github.com/walterbender/turtleblocksjs/raw/master/screenshots/foodplugin.png

It is causing an 404 error. I can't find this in the repo.